### PR TITLE
Form

### DIFF
--- a/src/components/DistBuilder.re
+++ b/src/components/DistBuilder.re
@@ -103,7 +103,10 @@ module Styles = {
       ),
     ]);
   let parent =
-    style([selector(".ant-input-number", [width(`percent(100.))])]);
+    style([
+      selector(".ant-input-number", [width(`percent(100.))]),
+      selector(".anticon", [verticalAlign(`zero)]),
+    ]);
   let form = style([backgroundColor(hex("eee")), padding(em(1.))]);
   let dist = style([padding(em(1.))]);
   let spacer = style([marginTop(em(1.))]);
@@ -139,6 +142,7 @@ module DemoDist = {
 
 [@react.component]
 let make = () => {
+  let (reloader, setRealoader) = React.useState(() => 1);
   let reform =
     Form.use(
       ~validationStrategy=OnDemand,
@@ -237,14 +241,27 @@ let make = () => {
         reform.state.values.sampleCount |> string_of_int,
         reform.state.values.outputXYPoints |> string_of_int,
         reform.state.values.truncateTo |> string_of_int,
+        reloader |> string_of_int,
       |],
     );
+
+  let onRealod = _ => {
+    setRealoader(_ => reloader + 1);
+  };
 
   <div className=Styles.parent>
     <div className=Styles.spacer />
     demoDist
     <div className=Styles.spacer />
-    <Antd.Card title={"Distribution Form" |> E.ste}>
+    <Antd.Card
+      title={"Distribution Form" |> E.ste}
+      extra={
+        <Antd.Button
+          icon=Antd.IconName.reload
+          shape=`circle
+          onClick=onRealod
+        />
+      }>
       <Form.Provider value=reform>
         <Antd.Form onSubmit>
           <Row _type=`flex className=Styles.rows>
@@ -353,6 +370,10 @@ let make = () => {
               <FieldNumber field=FormConfig.TruncateTo label="Truncate To" />
             </Col>
           </Row>
+          <Antd.Button
+            _type=`primary icon=Antd.IconName.reload onClick=onRealod>
+            {"Update Distribution" |> E.ste}
+          </Antd.Button>
         </Antd.Form>
       </Form.Provider>
     </Antd.Card>

--- a/src/components/DistBuilder.re
+++ b/src/components/DistBuilder.re
@@ -66,7 +66,7 @@ module FieldNumber = {
 
 module FieldFloat = {
   [@react.component]
-  let make = (~field, ~label) => {
+  let make = (~field, ~label, ~className=Css.style([])) => {
     <Form.Field
       field
       render={({handleChange, error, value, validate}) =>
@@ -78,6 +78,7 @@ module FieldFloat = {
               ();
             }}
             onBlur={_ => validate()}
+            className
           />
         </Antd.Form.Item>
       }
@@ -110,6 +111,20 @@ module Styles = {
   let form = style([backgroundColor(hex("eee")), padding(em(1.))]);
   let dist = style([padding(em(1.))]);
   let spacer = style([marginTop(em(1.))]);
+  let groupA =
+    style([
+      selector(
+        ".ant-input-number-input",
+        [backgroundColor(hex("fff7db"))],
+      ),
+    ]);
+  let groupB =
+    style([
+      selector(
+        ".ant-input-number-input",
+        [backgroundColor(hex("eaf4ff"))],
+      ),
+    ]);
 };
 
 module DemoDist = {
@@ -150,7 +165,7 @@ let make = () => {
       ~onSubmit=({state}) => {None},
       ~initialState={
         guesstimatorString: "mm(5 to 20, floor(normal(20,2)), [.5, .5])",
-        domainType: "Complete",
+        domainType: "LeftLimited",
         xPoint: 50.0,
         xPoint2: 60.0,
         excludingProbabilityMass2: 0.5,
@@ -296,31 +311,57 @@ let make = () => {
                 }
               />
             </Col>
-            <Col span=4>
-              <FieldFloat field=FormConfig.XPoint label="X-point" />
-            </Col>
-            <Col span=4>
-              <FieldFloat
-                field=FormConfig.ExcludingProbabilityMass
-                label="Excluding Probability Mass"
-              />
-            </Col>
-            <Col span=4>
-              <FieldFloat field=FormConfig.XPoint2 label="X-point (2)" />
-            </Col>
-            <Col span=4>
-              <FieldFloat
-                field=FormConfig.ExcludingProbabilityMass2
-                label="Excluding Probability Mass (2)"
-              />
-            </Col>
+            {<>
+               <Col span=4>
+                 <FieldFloat
+                   field=FormConfig.XPoint
+                   label="X-point"
+                   className=Styles.groupA
+                 />
+               </Col>
+               <Col span=4>
+                 <FieldFloat
+                   field=FormConfig.ExcludingProbabilityMass
+                   label="Excluding Probability Mass"
+                   className=Styles.groupA
+                 />
+               </Col>
+             </>
+             |> E.showIf(
+                  E.L.contains(
+                    reform.state.values.domainType,
+                    ["LeftLimited", "RightLimited", "LeftAndRightLimited"],
+                  ),
+                )}
+            {<>
+               <Col span=4>
+                 <FieldFloat
+                   field=FormConfig.XPoint2
+                   label="X-point (2)"
+                   className=Styles.groupB
+                 />
+               </Col>
+               <Col span=4>
+                 <FieldFloat
+                   field=FormConfig.ExcludingProbabilityMass2
+                   label="Excluding Probability Mass (2)"
+                   className=Styles.groupB
+                 />
+               </Col>
+             </>
+             |> E.showIf(
+                  E.L.contains(
+                    reform.state.values.domainType,
+                    ["LeftAndRightLimited"],
+                  ),
+                )}
           </Row>
           <Row _type=`flex className=Styles.rows>
             <Col span=4>
               <Form.Field
                 field=FormConfig.UnitType
                 render={({handleChange, value}) =>
-                  <Antd.Form.Item label={"Zero Type" |> E.ste}>
+                  <Antd.Form.Item label={"Unit Type" |> E.ste}>
                     <Antd.Select value onChange={e => e |> handleChange}>
                       <Antd.Select.Option value="UnspecifiedDistribution">
                         {"Unspecified Distribution" |> E.ste}
@@ -337,7 +378,7 @@ let make = () => {
               <Form.Field
                 field=FormConfig.Zero
                 render={({handleChange, value}) =>
-                  <Antd.Form.Item label={"Zero" |> E.ste}>
+                  <Antd.Form.Item label={"Zero Point" |> E.ste}>
                     <Antd_DatePicker
                       value
                       onChange={e => {
@@ -350,9 +391,41 @@ let make = () => {
               />
             </Col>
             <Col span=4>
-              <FieldFloat
-                field=FormConfig.ExcludingProbabilityMass
-                label="Excluding Probability Mass"
+              <Form.Field
+                field=FormConfig.Unit
+                render={({handleChange, value}) =>
+                  <Antd.Form.Item label={"Unit" |> E.ste}>
+                    <Antd.Select value onChange={e => e |> handleChange}>
+                      <Antd.Select.Option value="days">
+                        {"Days" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="hours">
+                        {"Hours" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="milliseconds">
+                        {"Milliseconds" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="minutes">
+                        {"Minutes" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="months">
+                        {"Months" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="quarters">
+                        {"Quarters" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="seconds">
+                        {"Seconds" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="weeks">
+                        {"Weeks" |> E.ste}
+                      </Antd.Select.Option>
+                      <Antd.Select.Option value="years">
+                        {"Years" |> E.ste}
+                      </Antd.Select.Option>
+                    </Antd.Select>
+                  </Antd.Form.Item>
+                }
               />
             </Col>
           </Row>

--- a/src/components/DistBuilder.re
+++ b/src/components/DistBuilder.re
@@ -280,7 +280,7 @@ let make = () => {
       <Form.Provider value=reform>
         <Antd.Form onSubmit>
           <Row _type=`flex className=Styles.rows>
-            <Col span=8>
+            <Col span=12>
               <FieldString
                 field=FormConfig.GuesstimatorString
                 label="Guesstimator String"

--- a/src/components/DistBuilder.re
+++ b/src/components/DistBuilder.re
@@ -195,8 +195,9 @@ let make = () => {
       })
     | "RightLimited" =>
       RightLimited({
-        xPoint: reform.state.values.xPoint,
-        excludingProbabilityMass: reform.state.values.excludingProbabilityMass,
+        xPoint: reform.state.values.xPoint2,
+        excludingProbabilityMass:
+          reform.state.values.excludingProbabilityMass2,
       })
     | "LeftAndRightLimited" =>
       LeftAndRightLimited(
@@ -315,14 +316,14 @@ let make = () => {
                <Col span=4>
                  <FieldFloat
                    field=FormConfig.XPoint
-                   label="X-point"
+                   label="Left X-point"
                    className=Styles.groupA
                  />
                </Col>
                <Col span=4>
                  <FieldFloat
                    field=FormConfig.ExcludingProbabilityMass
-                   label="Excluding Probability Mass"
+                   label="Left Excluding Probability Mass"
                    className=Styles.groupA
                  />
                </Col>
@@ -330,21 +331,21 @@ let make = () => {
              |> E.showIf(
                   E.L.contains(
                     reform.state.values.domainType,
-                    ["LeftLimited", "RightLimited", "LeftAndRightLimited"],
+                    ["LeftLimited", "LeftAndRightLimited"],
                   ),
                 )}
             {<>
                <Col span=4>
                  <FieldFloat
                    field=FormConfig.XPoint2
-                   label="X-point (2)"
+                   label="Right X-point"
                    className=Styles.groupB
                  />
                </Col>
                <Col span=4>
                  <FieldFloat
                    field=FormConfig.ExcludingProbabilityMass2
-                   label="Excluding Probability Mass (2)"
+                   label="Right Excluding Probability Mass"
                    className=Styles.groupB
                  />
                </Col>
@@ -352,7 +353,7 @@ let make = () => {
              |> E.showIf(
                   E.L.contains(
                     reform.state.values.domainType,
-                    ["LeftAndRightLimited"],
+                    ["RightLimited", "LeftAndRightLimited"],
                   ),
                 )}
           </Row>

--- a/src/utility/E.re
+++ b/src/utility/E.re
@@ -299,3 +299,4 @@ module JsArray = {
 };
 
 let ste = React.string;
+let showIf = (cond, comp) => cond ? comp : ReasonReact.null;


### PR DESCRIPTION
It was interesting to know how "Sample Count", "Output XY-points", and "Truncate To" affect a distribution view. 

1) Does the size of "xs" and "ys" much influence on the math logic of working with this data? Let say, would be there a difference between calculation in cases with {xs: Array(100), ys: Array(100)}? Keeping in mind that CDF/PDF is a numeric representation of the analytic form of functions, in this case of the probability distribution function.

2) What will be if I use trunсated CDF/PDF to calculate the users' scores in foretold.io?